### PR TITLE
Make the ko build work...

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	// The set of controllers this controller process runs.
-	"github.com/n3wscott/discovery/pkg/reconciler/DuckType"
+	"github.com/n3wscott/discovery/pkg/reconciler/ducktype"
 
 	// This defines the shared main for injected controllers.
 	"knative.dev/pkg/injection/sharedmain"


### PR DESCRIPTION
running `ko apply -f config/`,  I am getting this:

```
2020/02/05 09:03:56 Building github.com/n3wscott/discovery/cmd/controller
2020/02/05 09:03:56 Building github.com/n3wscott/discovery/cmd/webhook
2020/02/05 09:03:57 Unexpected error running "go build": exit status 1
cmd/controller/main.go:21:2: cannot find package "github.com/n3wscott/discovery/pkg/reconciler/DuckType" in any of:
	/home/matzew/go/src/github.com/n3wscott/discovery/vendor/github.com/n3wscott/discovery/pkg/reconciler/DuckType (vendor tree)
	/usr/local/go/src/github.com/n3wscott/discovery/pkg/reconciler/DuckType (from $GOROOT)
	/home/matzew/go/src/github.com/n3wscott/discovery/pkg/reconciler/DuckType (from $GOPATH)
2020/02/05 09:03:57 error processing import paths in "config/controller.yaml": exit status 1
```


Now, with this change, the build is successful  ... 

... and I eventually see:

```
knative-discovery   controller-5b85cd9bd8-fjv5p               1/1     Running   0          3m1s
knative-discovery   webhook-5dd7d6f6df-2clvz                  1/1     Running   0          3m1s
```